### PR TITLE
Fix event modal that overflow from screen since there's lot of detail

### DIFF
--- a/web/src/modules/eventModal/index.svelte
+++ b/web/src/modules/eventModal/index.svelte
@@ -73,7 +73,7 @@
               <Meta {item} />
 
               <article
-                class="mt-2 text-gray-600 dark:text-neutral-100 text-sm break-all"
+                class="max-h-72 overflow-auto mt-2 text-gray-600 dark:text-neutral-100 text-sm break-all"
               >
                 <p class="pb-2">
                   <a href={item.htmlLink} target="_blank" rel="noreferrer"


### PR DESCRIPTION
### Description
- Fix event modal that overflow from screen. For some example of event that caused result like this is "Generative AI" on 30 March 2023.
![image](https://user-images.githubusercontent.com/14361087/230701631-64a2f802-8e18-4be5-b3b8-2d67c61fad59.png)
![image](https://user-images.githubusercontent.com/14361087/230701730-a9561005-1511-4ebf-bd71-56cf7d64aeaa.png)

- Result from fix in this pull request.
<img width="1440" alt="Screenshot 2566-04-07 at 22 26 21" src="https://user-images.githubusercontent.com/14361087/230701751-d482125f-51d4-4f22-8b3d-258208953a53.png">
<img width="1440" alt="Screenshot 2566-04-07 at 22 26 35" src="https://user-images.githubusercontent.com/14361087/230701787-9e1b4f57-27c7-4886-aadf-0be96a76d8f1.png">
