### PR TITLE
Add capture mode

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,9 @@ importers:
 
   web:
     dependencies:
+      '@fontsource/anuphan':
+        specifier: ^5.0.8
+        version: 5.0.8
       autolinker:
         specifier: ^4.0.0
         version: 4.0.0
@@ -1418,6 +1421,10 @@ packages:
     os: [win32]
     requiresBuild: true
     optional: true
+
+  /@fontsource/anuphan@5.0.8:
+    resolution: {integrity: sha512-z+c11UA1QLv+msxhNnU9xRZQsLwsxN46LqH7jKJsszvifbTcMSqHLK+hxrlNNIj8L6mrEM7p59cQ/r3krUFt4Q==}
+    dev: false
 
   /@jridgewell/gen-mapping@0.1.1:
     resolution: {integrity: sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==}

--- a/web/package.json
+++ b/web/package.json
@@ -29,6 +29,7 @@
     "zx": "^7.2.1"
   },
   "dependencies": {
+    "@fontsource/anuphan": "^5.0.8",
     "autolinker": "^4.0.0",
     "dayjs": "^1.11.7",
     "svelte-headlessui": "^0.0.15",

--- a/web/src/context/captureEvent.ts
+++ b/web/src/context/captureEvent.ts
@@ -1,0 +1,5 @@
+import { writable } from 'svelte/store'
+
+import type { GoogleCalendarItem } from '$types/GoogleCalendar'
+
+export const captureEvent = writable<GoogleCalendarItem | null>(null)

--- a/web/src/context/captureMode.ts
+++ b/web/src/context/captureMode.ts
@@ -1,0 +1,3 @@
+import { writable } from 'svelte/store'
+
+export const captureMode = writable(false)

--- a/web/src/locale/index.ts
+++ b/web/src/locale/index.ts
@@ -3,6 +3,5 @@ import selectedLang from '$selectedLang'
 import type { LocaleKey } from '../@types/LocaleKey'
 
 export const l = (key: LocaleKey) => {
-  console.log({ selectedLang })
   return selectedLang[key]
 }

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -1,5 +1,6 @@
 import App from './app.svelte'
-
+import '@fontsource/anuphan/400.css'
+import '@fontsource/anuphan/700.css'
 import './styles/tailwind.css'
 
 const app = new App({

--- a/web/src/modules/calendar/desktop/day.svelte
+++ b/web/src/modules/calendar/desktop/day.svelte
@@ -3,6 +3,7 @@
 
   import type { Dayjs } from 'dayjs'
   import type { GoogleCalendarItem } from '$types/GoogleCalendar'
+  import { captureMode } from '$context/captureMode'
 
   export let date: Dayjs
   export let firstDayOfThisMonth: Dayjs
@@ -30,7 +31,7 @@
       <span class="font-semibold py-0.5">{date.format('MMMM')}</span>
     {/if}
     <span
-      class={diffFromToday === 0
+      class={diffFromToday === 0 && !$captureMode
         ? 'bg-orange-600 text-white px-2 rounded-md py-0.5'
         : 'py-0.5'}>{date.date()}</span
     >

--- a/web/src/modules/calendar/desktop/index.svelte
+++ b/web/src/modules/calendar/desktop/index.svelte
@@ -5,6 +5,7 @@
 
   import type { Dayjs } from 'dayjs'
   import type { GoogleCalendarItem } from '$types/GoogleCalendar'
+  import { captureMode } from '$context/captureMode'
 
   export let calendarDays: Dayjs[]
   export let firstDayOfThisMonth: Dayjs
@@ -40,13 +41,17 @@
   </div>
 </section>
 
-<footer class="pt-10 pb-8 text-xs text-center">
-  <p>
-    Originally made by <a href="https://twitter.com/thangman22">@thangman22</a>
-    · Redesigned by <a href="https://facebook.com/rayriffy">@rayriffy</a>
-  </p>
-  <p>
-    Maintained by <a href="https://creatorsgarten.org">Creatorsgarten</a> · Fork
-    me on <a href="https://github.com/creatorsgarten/techcal.dev">GitHub</a>
-  </p>
-</footer>
+{#if !$captureMode}
+  <footer class="pt-10 pb-8 text-xs text-center">
+    <p>
+      Originally made by <a href="https://twitter.com/thangman22">@thangman22</a
+      >
+      · Redesigned by <a href="https://facebook.com/rayriffy">@rayriffy</a>
+    </p>
+    <p>
+      Maintained by <a href="https://creatorsgarten.org">Creatorsgarten</a> ·
+      Fork me on
+      <a href="https://github.com/creatorsgarten/techcal.dev">GitHub</a>
+    </p>
+  </footer>
+{/if}

--- a/web/src/modules/calendar/index.svelte
+++ b/web/src/modules/calendar/index.svelte
@@ -6,10 +6,16 @@
   import Mobile from './mobile/index.svelte'
   import Renderer from './renderer.svelte'
 
-  let firstDayOfThisMonth = dayjs()
-    .tz('Asia/Bangkok')
-    .set('date', 1)
-    .startOf('day')
+  const initialMonth = (() => {
+    const params = new URLSearchParams(window.location.search)
+    const month = params.get('month')
+    if (month?.match(/^\d{4}-\d{2}$/)) {
+      return dayjs(month + '-01').tz('Asia/Bangkok')
+    }
+  })()
+
+  let firstDayOfThisMonth =
+    initialMonth || dayjs().tz('Asia/Bangkok').set('date', 1).startOf('day')
 
   let onShift = (amount: number) => () => {
     firstDayOfThisMonth = firstDayOfThisMonth.add(amount, 'month')

--- a/web/src/modules/event/index.svelte
+++ b/web/src/modules/event/index.svelte
@@ -1,10 +1,17 @@
 <script lang="ts">
   import { activeEvent } from '$context/activeEvent'
+  import { captureEvent } from '$context/captureEvent'
 
   import type { GoogleCalendarItem } from '$types/GoogleCalendar'
 
   export let item: GoogleCalendarItem
   export let dayDiff: number
+
+  $: captureHighlighted = $captureEvent?.id === item.id
+  $: color = captureHighlighted
+    ? 'bg-yellow-200 text-yellow-950 border-orange-500'
+    : `border-blue-950 text-blue-950 dark:text-blue-50 dark:border-blue-400 bg-blue-100 dark:bg-blue-500/40`
+  $: opacity = dayDiff < 0 ? 'opacity-50' : ''
 
   let onOpen = () => {
     activeEvent.set(item)
@@ -17,9 +24,7 @@
     on:click|preventDefault={onOpen}
     href={'/event/' + item.id}
     aria-label={item.summary}
-    class={`eventItem flex w-full rounded-md px-1.5 sm:px-1 py-0.5 sm:py-0  border-l-4 border-blue-950 text-blue-950 dark:text-blue-50 dark:border-blue-400 bg-blue-100 dark:bg-blue-500/40
-      ${dayDiff < 0 ? 'opacity-50' : ''}
-    `}
+    class={`eventItem flex w-full rounded-md px-1.5 sm:px-1 py-0.5 sm:py-0  border-l-4 ${color} ${opacity}`}
     ><span class="line-clamp-3 sm:line-clamp-1 text-sm text-left w-full"
       >{item.summary}</span
     ></a

--- a/web/src/modules/eventBanner/eventBanner.svelte
+++ b/web/src/modules/eventBanner/eventBanner.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  import TimeStringify from '$modules/event/timeStringify.svelte'
+  import Buildings from '$modules/icons/buildings.svelte'
+  import Time from '$modules/icons/time.svelte'
+  import type { GoogleCalendarItem } from '$types/GoogleCalendar'
+
+  export let item: GoogleCalendarItem
+</script>
+
+{#if item}
+  <div class="text-xl flex flex-col justify-center">
+    <div>
+      <div class="mb-2">
+        <strong class="bg-sky-700 text-white px-2 py-1 text-sm rounded"
+          >Tech event</strong
+        >
+      </div>
+      <h1 class="text-5xl font-bold mb-4 truncate">{item.summary}</h1>
+      {#if item.location}
+        <div class="flex pt-2 items-center space-x-3">
+          <Buildings class="w-4 h-4 shrink-0" />
+          <span class="truncate">{item.location}</span>
+        </div>
+      {/if}
+      <div class="flex pt-2 items-center space-x-3">
+        <Time class="w-4 h-4 shrink-0" />
+        <span>
+          <TimeStringify calendarTime={item.start} />
+          <span>–</span>
+          <TimeStringify calendarTime={item.end} />
+        </span>
+      </div>
+    </div>
+  </div>
+{/if}

--- a/web/src/modules/eventBanner/eventBanner.svelte
+++ b/web/src/modules/eventBanner/eventBanner.svelte
@@ -15,7 +15,9 @@
           >Tech event</strong
         >
       </div>
-      <h1 class="text-5xl font-bold mb-4 truncate">{item.summary}</h1>
+      <h1 id="capture-title" class="text-5xl font-bold mb-4 truncate">
+        {item.summary}
+      </h1>
       {#if item.location}
         <div class="flex pt-2 items-center space-x-3">
           <Buildings class="w-4 h-4 shrink-0" />


### PR DESCRIPTION
This will adjust the page layout so it’s easy to capture as social share image. Uses 2 params:

- `capture=<eventId>` — Which event to display as the event banner
- `month=YYYY-MM` — Which year/month to display on the calendar

## Example:

https://techcal-th--pr122-capture-jleg80z2.web.app/?capture=_60q30c1g60o30e1i60o4ac1g60rj8gpl88rj2c1h84s34h9g60s30c1g60o30c1g7123egq58l2k2cq28cr48e9g64o30c1g60o30c1g60o30c1g60o32c1g60o30c1g60o3ah9h8grkcdhj64sj2dpk8gs4cgpg88rj6ca674p48d9k60o0&month=2023-10

### Result:

![localhost_5173__capture=_60q30c1g60o30e1i60o4ac1g60rj8gpl88rj2c1h84s34h9g60s30c1g60o30c1g7123egq58l2k2cq28cr48e9g64o30c1g60o30c1g60o30c1g60o32c1g60o30c1g60o3ah9h8grkcdhj64sj2dpk8gs4cgpg88rj6ca674p48d9k60o0 month=2023-10](https://github.com/creatorsgarten/techcal.dev/assets/193136/59502df9-59fa-4fc4-bc93-50b4bcac14b4)

## Why?

I am thinking about reviving this page: https://www.facebook.com/thtechevents/

It currently has 600+ likes/followers, so we don’t have to start from zero.