### PR TITLE
[Hacktoberfest] Add a button to exporting the event to ICS file

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -35,6 +35,7 @@
     "autolinker": "^4.0.0",
     "dayjs": "^1.11.7",
     "iconify-icon": "^1.0.8",
+    "ics": "^3.5.0",
     "svelte-headlessui": "^0.0.15",
     "svelte-media-queries": "^1.5.4",
     "svelte-transition": "^0.0.7",


### PR DESCRIPTION
I've add a button to exporting an event to an iCal file so non-Google calendar user can easily subscribe to any specific event.

![image](https://github.com/creatorsgarten/techcal.dev/assets/3356814/7d3db6e3-ee35-4f72-81d2-897457d45797)

Note: This PR add `adamgibbons/ics` package. This package is needed in order to generate a file.